### PR TITLE
[#OCD-3456] - fix: use separate controller for different date-range directives

### DIFF
--- a/src/app/components/smart-table/chpl-joda-date-range.directive.js
+++ b/src/app/components/smart-table/chpl-joda-date-range.directive.js
@@ -2,7 +2,7 @@
     'use strict';
 
     angular.module('chpl.components')
-        .controller('ChplDateRangeController', ChplDateRangeController)
+        .controller('ChplJodaDateRangeController', ChplJodaDateRangeController)
         .directive('chplJodaDateRange', chplJodaDateRange);
 
     function chplJodaDateRange () {
@@ -12,7 +12,7 @@
                 nameSpace: '@?',
                 trackAnalytics: '@?',
             },
-            controller: 'ChplDateRangeController',
+            controller: 'ChplJodaDateRangeController',
             controllerAs: 'vm',
             link: chplDateRangeLink,
             restrict: 'E',
@@ -56,7 +56,7 @@
     }
 
     /** @ngInclude */
-    function ChplDateRangeController ($analytics, $filter, $localStorage, $log, DateUtil) {
+    function ChplJodaDateRangeController ($analytics, $filter, $localStorage, $log, DateUtil) {
         var vm = this;
 
         vm.$log = $log;


### PR DESCRIPTION
Both the original chplDateRange directive and the new chplJodaDateRange directive were registering controllers, but they had the same name. There can't be two controllers with the same name in an AngularJS app. I'm honestly not even sure how anything could have been working the way it was set up. Giving the new controller a different name lets the tests pass

That said, some notes of things that I'll look for in the upcoming PR:
* There should be tests for the new directive, even if they're not comprehensive, there ought to be at least "existence" tests
* I don't like the name of the new directive. Naming it based on the underlying technology breaks encapsulation best behaviors. It might make sense to rename the original one as `chplDateTimeRange` and let the new one be `chplDateRange`, and then update the various places the original one is used to use the new names. That way we're making the directive be specific about what kind of things it's providing filtering data for
* In the HTML for the new feature, please remove the part that is hidden based on the `ui-bump-major` flag, as we're already saying that we're going to implement stuff with that functionality on; no need to add more stuff that we'll need to remove anyway